### PR TITLE
Use install/remove hook to set add a PATH

### DIFF
--- a/profile
+++ b/profile
@@ -1,0 +1,7 @@
+# shellcheck shell=sh
+
+# Expand $PATH to include the bindir from the flutter snap
+flutter_bin_path="/snap/flutter/current/usr/bin"
+if [ -n "${PATH##*${flutter_bin_path}}" -a -n "${PATH##*${flutter_bin_path}:*}" ]; then
+    export PATH=$PATH:${flutter_bin_path}
+fi

--- a/profile
+++ b/profile
@@ -5,3 +5,5 @@ flutter_bin_path="/snap/flutter/current/usr/bin"
 if [ -n "${PATH##*${flutter_bin_path}}" -a -n "${PATH##*${flutter_bin_path}:*}" ]; then
     export PATH=$PATH:${flutter_bin_path}
 fi
+
+export FLUTTER_ROOT=${FLUTTER_ROOT-${HOME}/snap/flutter/common/flutter}

--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -2,4 +2,4 @@
 # Hook to ensure PATH is set properly
 
 mkdir -p /etc/profile.d
-cp ${SNAP}/profile /etc/profile.d/flutter-sdk-snap.sh
+cp ${SNAP}/profile /etc/profile.d/ZZflutter-sdk-snap.sh

--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -1,0 +1,5 @@
+#!/bin/sh -e
+# Hook to ensure PATH is set properly
+
+mkdir -p /etc/profile.d
+cp ${SNAP}/profile /etc/profile.d/flutter-sdk-snap.sh

--- a/snap/hooks/remove
+++ b/snap/hooks/remove
@@ -1,4 +1,4 @@
 #!/bin/sh -e
 # Hook to ensure PATH is set properly
 
-rm -f /etc/profile.d/flutter-sdk-snap.sh
+rm -f /etc/profile.d/ZZflutter-sdk-snap.sh

--- a/snap/hooks/remove
+++ b/snap/hooks/remove
@@ -1,0 +1,4 @@
+#!/bin/sh -e
+# Hook to ensure PATH is set properly
+
+rm -f /etc/profile.d/flutter-sdk-snap.sh

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -31,6 +31,7 @@ parts:
     source: .
     override-build: |
       cp flutter.sh $SNAPCRAFT_PART_INSTALL/
+      cp profile $SNAPCRAFT_PART_INSTALL/
     stage-packages:
       - jq
       - xz-utils


### PR DESCRIPTION
Use a hook to add usr/bin from the flutter snap to the path so external tools can find necessary binaries.  For example VS Code needs to find cmake.