### PR TITLE
Link /snap/bin/flutter to flutter.sh

### DIFF
--- a/flutter.sh
+++ b/flutter.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
-SCRIPT_DIR=`dirname $0`
-. $SCRIPT_DIR/env.sh
+. /snap/flutter/current/env.sh
 
 FLUTTER=$SNAP_USER_COMMON/flutter/bin/flutter
 

--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -1,0 +1,3 @@
+#!/bin/sh -e
+
+ln -sf /snap/flutter/current/flutter.sh /snap/bin/flutter


### PR DESCRIPTION
Following from the discussion in: https://github.com/kenvandine/flutter-snap/issues/8

Right now, VS Code needs to know the precise location of the flutter snap script (`/snap/flutter/current/flutter.sh`) in order to use the snap. A far better approach would be for it to call `flutter` from `$PATH` (`/snap/bin/flutter`), however, because the VS Code extension (and I assume many others) launches flutter as a daemon, the vscode snap is unable to grab the fd from the flutter snap (snap-to-snap). There’s an open bug for this:

https://bugs.launchpad.net/ubuntu/+source/snapd/+bug/1849753

I propose we simply replace `/snap/bin/flutter` with a link to `flutter.sh` in a configure hook so that we sidestep this issue. The snap is classic, so really it's unconfined, installing our own unconfined executable in `/snap/bin` is fair I think?

What do you think @kenvandine?